### PR TITLE
feat: simplify renovate configuration by removing unused options and using centralized configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,10 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "autoApprove": true,
-    "automerge": true,
-    "commitBodyTable": true,
-    "dependencyDashboardOSVVulnerabilitySummary": "all",
     "extends": [
         ":assignee(juancarlosjr97)",
-        ":enablePreCommit",
         ":reviewer(juancarlosjr97)",
-        ":semanticPrefixChore",
-        "config:recommended",
-        "group:all"
+        "github>juancarlosjr97/renovate-configuration#0.1.4"
     ],
-    "osvVulnerabilityAlerts": true,
-    "platformAutomerge": true,
     "pre-commit": {
         "fileMatch": [
             "(^|/)\\.pre-commit-config\\.ya?ml$",


### PR DESCRIPTION
This pull request simplifies and standardizes the Renovate configuration by removing redundant and deprecated settings and adopting a shared configuration file. The changes aim to streamline dependency management and ensure consistency across projects.

Key changes to Renovate configuration:

* Removed several individual configuration options, such as `autoApprove`, `automerge`, `commitBodyTable`, and `osvVulnerabilityAlerts`, which are now handled by the shared configuration.
* Replaced multiple `extends` entries, including `:enablePreCommit` and `:semanticPrefixChore`, with a single reference to the shared configuration file `github>juancarlosjr97/renovate-configuration#0.1.4`.
* Retained the `pre-commit` configuration for matching `.pre-commit-config.yml` files, ensuring compatibility with pre-commit hooks.

Fixes #25